### PR TITLE
Add intl_draft extension

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.0.3
+
+`intl_draft` extension added [PR](https://github.com/ahrefs/bs-react-intl-ppx/pull/5)
+
 ## 0.0.2
 Phrase context (description) is used for phrase id generation
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ let make = () => {
   let l = message => intl->ReactIntl.Intl.formatMessage(message);
 
   <>
-    <h1>[%intl "Some header"]->l->React.string</h2>
+    <h1>[%intl "Some header"]->l->React.string</h1>
     <p>[%intl "Some body"]->l->React.string</p>
   </>
 }
@@ -68,6 +68,10 @@ let make = (~item: ReactIntl.message, ~values: Js.t({..})) =>
   <ReactIntl.FormattedMessage id={item.id} defaultMessage={item.defaultMessage} values />;
 ```
 
+## Draft phrases
+
+If you want to make [extactor](https://github.com/cca-io/rescript-react-intl-extractor) ignore some phrases, you can use `intl_draft` / `intl_draft.s`/ `intl_draft.el` extensions.
+It is helpful if you don't want some draft phrases (likely to change soon) to be sent to translators.
 
 ## Advanced usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahrefs/bs-react-intl-ppx",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Generete ReactIntl.messages",
   "author": "Egor Chemokhonenko <egor.chemohonenko@ahrefs.com>",
   "license": "MIT",

--- a/src/BsReactIntlPpx.re
+++ b/src/BsReactIntlPpx.re
@@ -109,17 +109,17 @@ class mapper = {
   inherit class Ast_traverse.map as super;
   pub! expression = e =>
     switch (e) {
-    | {pexp_desc: Pexp_extension(({txt: "intl" | "intl_stub"}, payload))} =>
+    | {pexp_desc: Pexp_extension(({txt: "intl" | "intl_draft"}, payload))} =>
       makeIntlRecord(~payload, ~loc=e.pexp_loc)
 
     | {
-        pexp_desc: Pexp_extension(({txt: "intl.s" | "intl_stub.s"}, payload)),
+        pexp_desc: Pexp_extension(({txt: "intl.s" | "intl_draft.s"}, payload)),
       } =>
       makeStringResolver(~payload, ~loc=e.pexp_loc)
 
     | {
         pexp_desc:
-          Pexp_extension(({txt: "intl.el" | "intl_stub.el"}, payload)),
+          Pexp_extension(({txt: "intl.el" | "intl_draft.el"}, payload)),
       } =>
       makeReactElementResolver(~payload, ~loc=e.pexp_loc)
 

--- a/src/BsReactIntlPpx.re
+++ b/src/BsReactIntlPpx.re
@@ -109,21 +109,17 @@ class mapper = {
   inherit class Ast_traverse.map as super;
   pub! expression = e =>
     switch (e) {
-    | {
-        pexp_desc:
-          Pexp_extension(({txt: "intl" | "intl_stub", loc}, payload)),
-      } =>
+    | {pexp_desc: Pexp_extension(({txt: "intl" | "intl_stub"}, payload))} =>
       makeIntlRecord(~payload, ~loc=e.pexp_loc)
 
     | {
-        pexp_desc:
-          Pexp_extension(({txt: "intl.s" | "intl_stub.s", loc}, payload)),
+        pexp_desc: Pexp_extension(({txt: "intl.s" | "intl_stub.s"}, payload)),
       } =>
       makeStringResolver(~payload, ~loc=e.pexp_loc)
 
     | {
         pexp_desc:
-          Pexp_extension(({txt: "intl.el" | "intl_stub.el", loc}, payload)),
+          Pexp_extension(({txt: "intl.el" | "intl_stub.el"}, payload)),
       } =>
       makeReactElementResolver(~payload, ~loc=e.pexp_loc)
 

--- a/src/BsReactIntlPpx.re
+++ b/src/BsReactIntlPpx.re
@@ -3,7 +3,61 @@ open Ppxlib;
 let makeId = (~description="", message) =>
   message ++ "|" ++ description |> Digest.string |> Digest.to_hex;
 
-let makeIntlRecord = (~message, ~description=?, ~messageExp, ~loc, ()) => {
+let parsePayload = (~loc, payload) =>
+  switch (payload) {
+  // Match "message"
+  | {pexp_desc: Pexp_constant(Pconst_string(message, _, _)), _} as messageExp => (
+      message,
+      messageExp,
+      None,
+    )
+  // Match {msg: "message", desc: "description"}
+  | {
+      pexp_desc:
+        Pexp_record(
+          [
+            (
+              {txt: Lident("msg"), _},
+              {pexp_desc: Pexp_constant(Pconst_string(message, _, _)), _} as messageExp,
+            ),
+            (
+              {txt: Lident("desc"), _},
+              {
+                pexp_desc: Pexp_constant(Pconst_string(description, _, _)),
+                _,
+              },
+            ),
+          ] |
+          [
+            (
+              {txt: Lident("desc"), _},
+              {
+                pexp_desc: Pexp_constant(Pconst_string(description, _, _)),
+                _,
+              },
+            ),
+            (
+              {txt: Lident("msg"), _},
+              {pexp_desc: Pexp_constant(Pconst_string(message, _, _)), _} as messageExp,
+            ),
+          ],
+          None,
+        ),
+      _,
+    } => (
+      message,
+      messageExp,
+      Some(description),
+    )
+  | _ =>
+    Location.raise_errorf(
+      ~loc,
+      "react-intl-ppx expects the extension payload to be a constant string or a record ({msg: string, desc: string}), it does not work with any other expression types.",
+    )
+  };
+
+let makeIntlRecord = (~payload, ~loc) => {
+  let (message, messageExp, description) = parsePayload(~loc, payload);
   let id = makeId(~description?, message);
   let idExp = Ast_helper.Exp.constant(Pconst_string(id, loc, None));
   %expr
@@ -11,17 +65,14 @@ let makeIntlRecord = (~message, ~description=?, ~messageExp, ~loc, ()) => {
   ReactIntl.{id: [%e idExp], defaultMessage: [%e messageExp]};
 };
 
-let makeStringResolver = (~message, ~description=?, ~messageExp, ~loc, ()) => {
-  let recordExp =
-    makeIntlRecord(~message, ~description?, ~messageExp, ~loc, ());
+let makeStringResolver = (~payload, ~loc) => {
+  let recordExp = makeIntlRecord(~payload, ~loc);
   %expr
   ReactIntlPpxAdaptor.Message.to_s([%e recordExp]);
 };
 
-let makeReactElementResolver =
-    (~description=?, ~message, ~messageExp, ~loc, ()) => {
-  let stringResolverExp =
-    makeStringResolver(~message, ~description?, ~messageExp, ~loc, ());
+let makeReactElementResolver = (~payload, ~loc) => {
+  let stringResolverExp = makeStringResolver(~payload, ~loc);
   %expr
   React.string([%e stringResolverExp]);
 };
@@ -31,206 +82,33 @@ class mapper = {
   inherit class Ast_traverse.map as super;
   pub! expression = e =>
     switch (e) {
-    // Match [%intl "message"]
-    | [%expr
-        [%intl
-          [%e?
-            {pexp_desc: Pexp_constant(Pconst_string(message, _, _)), _} as messageExp
-          ]
-        ]
-      ] =>
-      makeIntlRecord(~message, ~messageExp, ~loc=e.pexp_loc, ())
+    | {
+        pexp_desc:
+          Pexp_extension((
+            {txt: "intl" | "intl_stub", loc},
+            PStr([{pstr_desc: Pstr_eval(payload, _)}]),
+          )),
+      } =>
+      makeIntlRecord(~payload, ~loc=e.pexp_loc)
 
-    // Match [%intl {msg: "message", desc: "description"}]
-    // and [%intl {desc: "description", msg: "message"}]
-    | [%expr
-        [%intl
-          [%e?
-            {
-              pexp_desc:
-                Pexp_record(
-                  [
-                    (
-                      {txt: Lident("msg"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(message, _, _)),
-                        _,
-                      } as messageExp,
-                    ),
-                    (
-                      {txt: Lident("desc"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(description, _, _)),
-                        _,
-                      },
-                    ),
-                  ] |
-                  [
-                    (
-                      {txt: Lident("desc"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(description, _, _)),
-                        _,
-                      },
-                    ),
-                    (
-                      {txt: Lident("msg"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(message, _, _)),
-                        _,
-                      } as messageExp,
-                    ),
-                  ],
-                  None,
-                ),
-              _,
-            }
-          ]
-        ]
-      ] =>
-      makeIntlRecord(~message, ~description, ~messageExp, ~loc=e.pexp_loc, ())
+    | {
+        pexp_desc:
+          Pexp_extension((
+            {txt: "intl.s" | "intl_stub.s", loc},
+            PStr([{pstr_desc: Pstr_eval(payload, _)}]),
+          )),
+      } =>
+      makeStringResolver(~payload, ~loc=e.pexp_loc)
 
-    // Match [%intl.s "message"]
-    | [%expr
-        [%intl.s
-          [%e?
-            {pexp_desc: Pexp_constant(Pconst_string(message, _, _)), _} as messageExp
-          ]
-        ]
-      ] =>
-      makeStringResolver(~message, ~messageExp, ~loc=e.pexp_loc, ())
+    | {
+        pexp_desc:
+          Pexp_extension((
+            {txt: "intl.el" | "intl_stub.el", loc},
+            PStr([{pstr_desc: Pstr_eval(payload, _)}]),
+          )),
+      } =>
+      makeReactElementResolver(~payload, ~loc=e.pexp_loc)
 
-    // Match [%intl.s {msg: "message", desc: "description}]
-    // and [%intl.s {desc: "description", msg: "message"}]
-    | [%expr
-        [%intl.s
-          [%e?
-            {
-              pexp_desc:
-                Pexp_record(
-                  [
-                    (
-                      {txt: Lident("msg"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(message, _, _)),
-                        _,
-                      } as messageExp,
-                    ),
-                    (
-                      {txt: Lident("desc"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(description, _, _)),
-                        _,
-                      },
-                    ),
-                  ] |
-                  [
-                    (
-                      {txt: Lident("desc"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(description, _, _)),
-                        _,
-                      },
-                    ),
-                    (
-                      {txt: Lident("msg"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(message, _, _)),
-                        _,
-                      } as messageExp,
-                    ),
-                  ],
-                  None,
-                ),
-              _,
-            }
-          ]
-        ]
-      ] =>
-      makeStringResolver(
-        ~message,
-        ~description,
-        ~messageExp,
-        ~loc=e.pexp_loc,
-        (),
-      )
-
-    // Match [%intl.el "message"]
-    | [%expr
-        [%intl.el
-          [%e?
-            {pexp_desc: Pexp_constant(Pconst_string(message, _, _)), _} as messageExp
-          ]
-        ]
-      ] =>
-      makeReactElementResolver(~message, ~messageExp, ~loc=e.pexp_loc, ())
-
-    // Match [%intl.el {msg: "message", desc: "description"}]
-    // And [%intl.el {desc: "description", msg: "message"}]
-    | [%expr
-        [%intl.el
-          [%e?
-            {
-              pexp_desc:
-                Pexp_record(
-                  [
-                    (
-                      {txt: Lident("msg"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(message, _, _)),
-                        _,
-                      } as messageExp,
-                    ),
-                    (
-                      {txt: Lident("desc"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(description, _, _)),
-                        _,
-                      },
-                    ),
-                  ] |
-                  [
-                    (
-                      {txt: Lident("desc"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(description, _, _)),
-                        _,
-                      },
-                    ),
-                    (
-                      {txt: Lident("msg"), _},
-                      {
-                        pexp_desc:
-                          Pexp_constant(Pconst_string(message, _, _)),
-                        _,
-                      } as messageExp,
-                    ),
-                  ],
-                  None,
-                ),
-              _,
-            }
-          ]
-        ]
-      ] =>
-      makeReactElementResolver(
-        ~message,
-        ~description,
-        ~messageExp,
-        ~loc=e.pexp_loc,
-        (),
-      )
     | {
         pexp_desc:
           Pexp_extension(({txt: "intl" | "intl.s" | "intl.el", loc}, _)),


### PR DESCRIPTION
In this PR I added `intl_draft` / `intl_draft.s`/`intl_draft.el` extensions.

These extensions usage produces exactly the same code as `intl`/`intl.s`/`intl.el` but doesn't match [rescript-react-intl-extractor](https://github.com/cca-io/rescript-react-intl-extractor) rules- it is helpful if you don't want some phrases to be extracted (text/labels for WIP features)

Also in this PR, I moved the payload matcher to the reusable  function