### PR TITLE
Remove windows build

### DIFF
--- a/.github/workflows/bs-react-intl-ppx.yml
+++ b/.github/workflows/bs-react-intl-ppx.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest]
     steps:
       - uses: actions/setup-node@v1
         with:
@@ -101,13 +101,6 @@ jobs:
           name: macos-latest
           path: binaries/darwin
 
-      - name: Download windows artifacts
-        if: success()
-        uses: actions/download-artifact@v2
-        with:
-          name: windows-latest
-          path: binaries/windows
-
       - name: Move artifacts
         if: success()
         run: |
@@ -115,7 +108,6 @@ jobs:
           ls -la binaries
           ls -la binaries/darwin
           mv binaries/darwin/BsReactIntlPpxBin.exe exe/bs-react-intl-ppx-darwin-x64.exe
-          mv binaries/windows/BsReactIntlPpxBin.exe exe/bs-react-intl-ppx-win-x64.exe
           mv binaries/linux/BsReactIntlPpxBin.exe exe/bs-react-intl-ppx-linux-x64.exe
 
       - name: Upload artifacts ${{ matrix.os }}


### PR DESCRIPTION
Windows build is failing with https://github.com/ahrefs/bs-react-intl-ppx/runs/5422906459?check_suite_focus=true#step:11:34
```
error: build failed with exit code: 1
  build log:
    # esy-build-package: building: @opam/reason@opam:3.7.0

    # esy-build-package: pwd: C:\Users\runneradmin\.esy\3\b\opam__s__reason-opam__c__3.7.0-aec9a6f8

    # esy-build-package: running: "dune" "build" "-p" "reason" "-j" "4"

    Error:

    _build/.sandbox/b9baba63433bfe823587aa30e818496c/default/src/vendored-ocaml-migrate-parsetree-v1.8.0/src/.reason_migrate_parsetree.objs/byte/reason_migrate_parsetree__Migrate_parsetree_402_403.cmi:

    No such file or directory

    -> required by

       _build/default/src/reason-parser/reason_parser__mock.mli.inferred

    -> required by _build/default/src/reason-parser/reason_parser.ml

    -> required by _build/install/default/lib/reason/reason_parser.ml

    -> required by _build/default/reason.install

    -> required by alias install

    error: command failed: "dune" "build" "-p" "reason" "-j" "4" (exited with 1)

    esy-build-package: exiting with errors above...
```

Disabling it for now