### PR TITLE
Do not produce fast pipe

### DIFF
--- a/src/Resolver.re
+++ b/src/Resolver.re
@@ -163,14 +163,14 @@ let makeReactElement = (~payload, ~loc) => {
   switch (variables) {
   | [] =>
     %expr
-    ReactIntlPpxAdaptor.Message.to_s([%e recordExp])->React.string
+    ReactIntlPpxAdaptor.Message.to_s([%e recordExp]) |> React.string
   | variables =>
     let valuesType = variables |> makeValuesType(~loc);
     %expr
     (
       (values: Js.t([%t valuesType])) =>
         ReactIntlPpxAdaptor.Message.format_to_s([%e recordExp], values)
-        ->React.string
+        |> React.string
     );
   };
 };

--- a/src/Resolver.re
+++ b/src/Resolver.re
@@ -163,14 +163,15 @@ let makeReactElement = (~payload, ~loc) => {
   switch (variables) {
   | [] =>
     %expr
-    ReactIntlPpxAdaptor.Message.to_s([%e recordExp]) |> React.string
+    React.string(ReactIntlPpxAdaptor.Message.to_s([%e recordExp]))
   | variables =>
     let valuesType = variables |> makeValuesType(~loc);
     %expr
     (
       (values: Js.t([%t valuesType])) =>
-        ReactIntlPpxAdaptor.Message.format_to_s([%e recordExp], values)
-        |> React.string
+        React.string(
+          ReactIntlPpxAdaptor.Message.format_to_s([%e recordExp], values)
+        )
     );
   };
 };


### PR DESCRIPTION
We are currently using this ppx on the server with `server-reason-react`, but there is a problem with producing fast pipes in the output: existing ppxes for fast-pipe run before `bs-react-intl-ppx`  runs and the build fails with:
```
Error: Unbound value |.
```

I don't see a reason why fast-pipe in the output is needed, so replacing with universal regular pipe. Maybe it even make sense to get rid of pipes in the output completely. 


