### PR TITLE
Make zero,  one, and few plural branches optional

### DIFF
--- a/ppx/Regexp.re
+++ b/ppx/Regexp.re
@@ -2,7 +2,7 @@ let variable = Re.Pcre.regexp("\\{(\\w+)}");
 
 let plural =
   Re.Pcre.regexp(
-    "\\{(\\w+), plural,(?: zero \\{[^\\}]+\\})? one \\{[^\\}]+\\}(?: few \\{[^\\}]+\\})?(?: many \\{[^\\}]+\\})? other \\{[A-Za-z ]+\\}\\}",
+    "\\{(\\w+), plural,(?: zero \\{[^\\}]+\\})?(?: one \\{[^\\}]+\\})?(?: few \\{[^\\}]+\\})?(?: many \\{[^\\}]+\\})? other \\{[A-Za-z ]+\\}\\}",
   );
 
 let findAll = (~regexp, s) =>

--- a/ppx/Regexp.re
+++ b/ppx/Regexp.re
@@ -2,7 +2,7 @@ let variable = Re.Pcre.regexp("\\{(\\w+)}");
 
 let plural =
   Re.Pcre.regexp(
-    "\\{(\\w+), plural, zero \\{[^\\}]+\\} one \\{[^\\}]+\\} few \\{[^\\}]+\\}(?: many \\{[^\\}]+\\})? other \\{[A-Za-z ]+\\}\\}",
+    "\\{(\\w+), plural,(?: zero \\{[^\\}]+\\})? one \\{[^\\}]+\\}(?: few \\{[^\\}]+\\})?(?: many \\{[^\\}]+\\})? other \\{[A-Za-z ]+\\}\\}",
   );
 
 let findAll = (~regexp, s) =>

--- a/test/ppx/simple.t/input.re
+++ b/test/ppx/simple.t/input.re
@@ -50,6 +50,14 @@ let stringWithPluralFormNoZeroNoFew: {. "itemsCount": int} => string = [%intl.s
   "{itemsCount, plural, one {item} other {items}}"
 ];
 
+let stringWithPluralFormNoOne: {. "itemsCount": int} => string = [%intl.s
+  "{itemsCount, plural, zero {item} few {items} many {items} other {items}}"
+];
+
+let stringWithPluralFormOnlyOther: {. "itemsCount": int} => string = [%intl.s
+  "{itemsCount, plural, other {items}}"
+];
+
 let elementWithRichText: {. "a": string => React.element} => React.element = [%intl.el
   "Some text with <a>link text</a>"
 ];

--- a/test/ppx/simple.t/input.re
+++ b/test/ppx/simple.t/input.re
@@ -38,6 +38,18 @@ let elementWithPluralForm: {. "itemsCount": int} => React.element = [%intl.el
   "{itemsCount, plural, zero {item} one {item} few {items} many {items} other {items}}"
 ];
 
+let stringWithPluralFormNoZero: {. "itemsCount": int} => string = [%intl.s
+  "{itemsCount, plural, one {item} few {items} many {items} other {items}}"
+];
+
+let stringWithPluralFormNoFew: {. "itemsCount": int} => string = [%intl.s
+  "{itemsCount, plural, zero {item} one {item} many {items} other {items}}"
+];
+
+let stringWithPluralFormNoZeroNoFew: {. "itemsCount": int} => string = [%intl.s
+  "{itemsCount, plural, one {item} other {items}}"
+];
+
 let elementWithRichText: {. "a": string => React.element} => React.element = [%intl.el
   "Some text with <a>link text</a>"
 ];

--- a/test/ppx/simple.t/run.t
+++ b/test/ppx/simple.t/run.t
@@ -112,6 +112,45 @@
         },
         values,
       );
+  let stringWithPluralFormNoZero: {. "itemsCount": int} => string =
+    (values: {. "itemsCount": int}) => (
+      ReactIntlPpxAdaptor.Message.format_to_s(
+        ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
+        [@warning "-45"]
+        ReactIntl.{
+          id: "4bd22beea7e3314a3932db7f44bf5d09",
+          defaultMessage: "{itemsCount, plural, one {item} few {items} many {items} other {items}}",
+          maxLength: None,
+        },
+        values,
+      ): string
+    );
+  let stringWithPluralFormNoFew: {. "itemsCount": int} => string =
+    (values: {. "itemsCount": int}) => (
+      ReactIntlPpxAdaptor.Message.format_to_s(
+        ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
+        [@warning "-45"]
+        ReactIntl.{
+          id: "16803d1a875cd1508f82a14149b1a1e0",
+          defaultMessage: "{itemsCount, plural, zero {item} one {item} many {items} other {items}}",
+          maxLength: None,
+        },
+        values,
+      ): string
+    );
+  let stringWithPluralFormNoZeroNoFew: {. "itemsCount": int} => string =
+    (values: {. "itemsCount": int}) => (
+      ReactIntlPpxAdaptor.Message.format_to_s(
+        ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
+        [@warning "-45"]
+        ReactIntl.{
+          id: "885a4d7a970a7515c3e340cdaccfc03b",
+          defaultMessage: "{itemsCount, plural, one {item} other {items}}",
+          maxLength: None,
+        },
+        values,
+      ): string
+    );
   let elementWithRichText: {. "a": string => React.element} => React.element =
     (values: {. "a": string => React.element}) =>
       ReactIntlPpxAdaptor.Message.format_to_el(

--- a/test/ppx/simple.t/run.t
+++ b/test/ppx/simple.t/run.t
@@ -151,6 +151,32 @@
         values,
       ): string
     );
+  let stringWithPluralFormNoOne: {. "itemsCount": int} => string =
+    (values: {. "itemsCount": int}) => (
+      ReactIntlPpxAdaptor.Message.format_to_s(
+        ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
+        [@warning "-45"]
+        ReactIntl.{
+          id: "45bf442cb090ff6a13b064b17e14300e",
+          defaultMessage: "{itemsCount, plural, zero {item} few {items} many {items} other {items}}",
+          maxLength: None,
+        },
+        values,
+      ): string
+    );
+  let stringWithPluralFormOnlyOther: {. "itemsCount": int} => string =
+    (values: {. "itemsCount": int}) => (
+      ReactIntlPpxAdaptor.Message.format_to_s(
+        ~list_of_values=[("itemsCount", `Number(values##itemsCount))],
+        [@warning "-45"]
+        ReactIntl.{
+          id: "081ae6d38f86613b243dd3e97503454c",
+          defaultMessage: "{itemsCount, plural, other {items}}",
+          maxLength: None,
+        },
+        values,
+      ): string
+    );
   let elementWithRichText: {. "a": string => React.element} => React.element =
     (values: {. "a": string => React.element}) =>
       ReactIntlPpxAdaptor.Message.format_to_el(


### PR DESCRIPTION
We should allow localizable strings like this:

```
I've got {countStr} {count, plural, one {bird} other {birds}} in my hand
```
and this (assume more than one):
```
You have {count} {count, plural, other {options}}
```

The justification is that in English, `zero` and `few` branches are irrelevant when `other` branch is present.

We also want to support the case of "Last N months", where we'd split this into two separate strings:
```
Last month
```
and
```
Last {countStr} {count, plural, other {months}}
```
where the second string doesn't need to have the `one` branch which is already covered by the first string.